### PR TITLE
Adds MMBN3 to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Currently, the following games are supported:
 * The Legend of Zelda: Link's Awakening DX
 * Clique
 * Adventure
+* Mega Man Battle Network 3: Blue Version
 
 For setup and instructions check out our [tutorials page](https://archipelago.gg/tutorial/).
 Downloads can be found at [Releases](https://github.com/ArchipelagoMW/Archipelago/releases), including compiled


### PR DESCRIPTION
## What is this fixing or adding?
- Adds Mega Man Battle Network 3: Blue Version to the list of games supported by AP in the readme