### PR TITLE
Adds No Bank

### DIFF
--- a/worlds/osrs/Items.py
+++ b/worlds/osrs/Items.py
@@ -78,6 +78,11 @@ chunksanity_starting_chunks: typing.List[str] = [
     ItemNames.Wilderness
 ]
 
+# Have to skip three names for any bank, no bank, and chunksanity
+non_starting_area_dict: typing.Dict[int, str] = { idx + 3 + len(starting_area_dict) : name for idx,name in enumerate(chunksanity_starting_chunks)}
+
+all_starting_area_dict: typing.Dict[int, str] = starting_area_dict|non_starting_area_dict
+
 # Some starting areas contain multiple regions, so if that area is rolled for Chunksanity, we need to map it to one
 chunksanity_special_region_names: typing.Dict[str, str] = {
     ItemNames.Lumbridge_Farms: 'Lumbridge Farms East',

--- a/worlds/osrs/Options.py
+++ b/worlds/osrs/Options.py
@@ -24,6 +24,7 @@ class StartingArea(Choice):
     area, but any areas that require quests, skills, or coins are not available as a starting location.
 
     "Any Bank" rolls a random region that contains a bank.
+    "No Bank" rolls a random region that *doesn't* contain a bank, have fun!
     Chunksanity can start you in any chunk. Hope you like woodcutting!
     """
     display_name = "Starting Region"
@@ -35,9 +36,25 @@ class StartingArea(Choice):
     option_falador = 5
     option_draynor = 6
     option_wilderness = 7
-    option_any_bank = 8
-    option_chunksanity = 9
+    option_no_bank = 8
+    option_any_bank = 9
+    option_chunksanity = 10
     default = 0
+
+    @classmethod
+    def from_text(cls, text: str) -> Choice:
+        from .Items import all_starting_area_dict
+        canadites = [item for item, name in all_starting_area_dict.items() if name.lower()[6:] == text.lower() ] # ignore the "Area: " prefix
+        if len(canadites) == 1: # Error on any non-exact match
+            return StartingArea(canadites[0])
+        return super().from_text(text)
+    
+    @classmethod
+    def get_option_name(cls, value: int) -> str:
+        from .Items import all_starting_area_dict
+        if value in all_starting_area_dict:
+            return all_starting_area_dict[value][6:]
+        return super().get_option_name(value)
 
 class OSRSGoal(Choice):
     """

--- a/worlds/osrs/__init__.py
+++ b/worlds/osrs/__init__.py
@@ -3,7 +3,7 @@ import typing
 from BaseClasses import Item, Tutorial, ItemClassification, Region, MultiWorld, CollectionState
 from worlds.AutoWorld import WebWorld, World
 from Options import OptionError
-from .Items import OSRSItem, starting_area_dict, chunksanity_starting_chunks, QP_Items, ItemRow, \
+from .Items import OSRSItem, non_starting_area_dict, starting_area_dict, all_starting_area_dict, chunksanity_starting_chunks, QP_Items, ItemRow, \
     chunksanity_special_region_names
 from .Locations import OSRSLocation, LocationRow, task_types
 from .Rules import *
@@ -106,10 +106,12 @@ class OSRSWorld(World):
         if not hasattr(self.multiworld, "generation_is_fake"):
             if starting_area.value == StartingArea.option_any_bank:
                 self.starting_area_item = rnd.choice(starting_area_dict)
-            elif starting_area.value < StartingArea.option_chunksanity:
-                self.starting_area_item = starting_area_dict[starting_area.value]
-            else:
+            if starting_area.value == StartingArea.option_no_bank:
+                self.starting_area_item = rnd.choice(non_starting_area_dict)
+            elif starting_area.value == StartingArea.option_chunksanity:
                 self.starting_area_item = rnd.choice(chunksanity_starting_chunks)
+            else:
+                self.starting_area_item = all_starting_area_dict[starting_area.value]
 
             # Set Starting Chunk
             self.multiworld.push_precollected(self.create_item(self.starting_area_item))


### PR DESCRIPTION
Also allows users to input an item name (without the "Area: " prefix) to force any chunksanity-valid chunk as starting area
